### PR TITLE
don't specify crate-type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,4 @@ name = "rustdoc-stripper"
 tempdir = "0.3.4"
 
 [lib]
-crate-type = ["dylib", "rlib"]
 name = "stripper_lib"


### PR DESCRIPTION
As @GuillaumeGomez says, it is leftover from times when cargo required to
specify crate-type and we don't need that nowadays.

Closes: https://github.com/GuillaumeGomez/rustdoc-stripper/issues/48