### PR TITLE
Github Actions support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,110 @@
+name: "rustdoc-stripper"
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "*"
+
+jobs:
+  hygiene:
+    name: Hygiene
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        toolchain: [stable, beta, nightly]
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Acquire source code
+        uses: actions/checkout@v2
+      - name: Acquire Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+          profile: minimal
+          components: rustfmt, clippy
+        id: toolchain
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: checks-${{ runner.os }}-cargo-registry-trimmed
+      - name: Cache cargo git trees
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: checks-${{ runner.os }}-cargo-gits-trimmed
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: checks-${{ runner.os }}-cargo-target-dir-${{ steps.toolchain.outputs.rustc_hash }}
+      - name: "Run clippy"
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --release --tests -- -D warnings
+      - name: "Run formatting check"
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check
+
+  build:
+    name: "Build/Test"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        toolchain: [nightly, beta, stable]
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Acquire source code
+        uses: actions/checkout@v2
+      - name: Acquire Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+          profile: minimal
+          components: rustfmt, clippy
+        id: toolchain
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: checks-${{ runner.os }}-cargo-registry-trimmed
+      - name: Cache cargo git trees
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: checks-${{ runner.os }}-cargo-gits-trimmed
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: checks-${{ runner.os }}-cargo-target-dir-${{ steps.toolchain.outputs.rustc_hash }}
+      - name: "Set backtraces on"
+        run: echo "::set-env name=RUST_BACKTRACE::1"
+      - name: "Run build"
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+      - name: "Run tests"
+        uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: rust
-rust:
-- nightly
-- beta
-- stable
-script:
-  - rustc --version
-  - RUST_BACKTRACE=1 cargo build
-  - RUST_BACKTRACE=1 cargo test

--- a/src/strip.rs
+++ b/src/strip.rs
@@ -135,11 +135,7 @@ fn get_three_parts<'a>(
     stop: &str,
 ) -> (String, String, &'a str) {
     if let Some(pos) = after.find(stop) {
-        let extra = if stop != "\n" {
-            stop.len()
-        } else {
-            0
-        };
+        let extra = if stop != "\n" { stop.len() } else { 0 };
         (
             before.to_owned(),
             format!("{} {}", comment_sign, &after[0..pos]),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1248,7 +1248,7 @@ mod foobar {
 }
 "#;
 
-fn get_basic12_md(file: &str) -> String {
+fn get_basic12_md(_file: &str) -> String {
     String::new()
 }
 


### PR DESCRIPTION
This replaces your travis configuration with github actions.  Rough runtime in my tests was around 1 minute for all tests.  May need merging before it will run properly on PRs, here's an example run: https://github.com/kinnison/rustdoc-stripper/actions/runs/93956711