### PR TITLE
Skip past all tokens in function signatures

### DIFF
--- a/src/strip.rs
+++ b/src/strip.rs
@@ -421,7 +421,7 @@ fn build_event_inner(
                     EventType::Type(TypeStruct::new(Type::from(ty), &name)),
                 ));
             }
-            "struct" | "fn" | "enum" | "const" | "static" | "type" | "trait" | "macro_rules!"
+            "struct" | "enum" | "const" | "static" | "type" | "trait" | "macro_rules!"
             | "flags" => {
                 if *it + 1 >= words.len() {
                     break;
@@ -435,6 +435,32 @@ fn build_event_inner(
                 ));
                 waiting_for_macro = words[*it] == "macro_rules!";
                 *it += 1;
+            }
+            "fn" => {
+                if *it + 1 >= words.len() {
+                    break;
+                }
+                let name = get_before(words[*it + 1], STOP_CHARACTERS);
+                event_list.push(EventInfo::new(
+                    *line,
+                    EventType::Type(TypeStruct::new(Type::from(words[*it]), name)),
+                ));
+                *it += 1;
+                if !name.is_empty() {
+                    while let Some(&word) = words.get(*it) {
+                        if word.ends_with(';') {
+                            break;
+                        }
+                        if word.starts_with("{") {
+                            *it -= 1;
+                            break;
+                        }
+                        if word == "\n" {
+                            *line += 1;
+                        }
+                        *it += 1;
+                    }
+                }
             }
             "!!" => {
                 event_list.push(EventInfo::new(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1866,3 +1866,42 @@ This thing can be read.
     );
     compare_files(TARGET_RS, &temp_dir.path().join(src_path));
 }
+
+#[test]
+fn fn_with_impl_arg_and_ret() {
+    static SRC_RS: &str = r###"
+        trait ObjectExt {
+            fn impl_arg(&self, t: impl Trait) -> i32;
+            fn impl_no_arg(&self) -> i32;
+        }
+    "###;
+    static DOCS_MD: &str = r###"<!-- file * -->
+<!-- trait ObjectExt::fn impl_arg  -->
+A function that takes an impl trait arg.
+<!-- trait ObjectExt::fn impl_no_arg  -->
+A function that takes no arguments.
+"###;
+    static TARGET_RS: &str = r###"
+        trait ObjectExt {
+            /// A function that takes an impl trait arg.
+            fn impl_arg(&self, t: impl Trait) -> i32;
+            /// A function that takes no arguments.
+            fn impl_no_arg(&self) -> i32;
+        }
+    "###;
+
+    let src_path = "fnimpl.rs";
+    let docs_path = "fnimpl-docs.md";
+    let temp_dir = tempdir().unwrap();
+    gen_file(&temp_dir, src_path, SRC_RS);
+    gen_file(&temp_dir, docs_path, DOCS_MD);
+
+    stripper_lib::regenerate_doc_comments(
+        temp_dir.path().to_str().unwrap(),
+        false,
+        temp_dir.path().join(docs_path).to_str().unwrap(),
+        false,
+        false,
+    );
+    compare_files(TARGET_RS, &temp_dir.path().join(src_path));
+}


### PR DESCRIPTION
The parsing breaks when there is an `impl` keyword in a function signature, it causes all the `fn`s after it to get skipped over. See everything in the docs below this `fn`: https://gtk-rs.org/gtk4-rs/stable/0.6/docs/gtk4/prelude/trait.WidgetExt.html#tymethod.add_controller

This seems to fix it by just skipping the whole signature. I had to check if the function name was empty to avoid applying the rule inside a `fn(...)` type.